### PR TITLE
Fix macro parameter case.

### DIFF
--- a/relax.cfg
+++ b/relax.cfg
@@ -20,11 +20,10 @@ description: "Cycle to release parts from bed and perform destress heating"
 gcode:
 
     # Assign parameters or use default values
-    {% set release_temp = params.release_temp|default(40)|float %}      # Target temperature to release parts from bed
-    {% set release_time = params.release_time|default(300)|int %}       # Time (in seconds) at release temperature
-    {% set destress_temp = params.destress_temp|default(105)|float %}   # Target temperature for destress cycle
-    {% set destress_time = params.destress_time|default(300)|int %}     # Time (in seconds) at destress temperature
-
+    {% set release_temp = params.RELEASE_TEMP|default(40)|float %}      # Target temperature to release parts from bed
+    {% set release_time = params.RELEASE_TIME|default(300)|int %}       # Time (in seconds) at release temperature
+    {% set destress_temp = params.DESTRESS_TEMP|default(105)|float %}   # Target temperature for destress cycle
+    {% set destress_time = params.DESTRESS_TIME|default(300)|int %}     # Time (in seconds) at destress temperature
     RESPOND MSG="Starting RELAX Cycle..."
 
     # Step 1: Cooldown to release temperature (only if current temperature is higher)


### PR DESCRIPTION
Wasn't able to successfully pass parameters to the macro as-is. Had to update the case of the parameters.

"Note that parameter names are always in upper-case when evaluated in the macro and are always passed as strings."

Ref: https://www.klipper3d.org/Command_Templates.html#macro-parameters